### PR TITLE
Suggested update to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,12 +467,18 @@ Awesome Conformal Prediction [[GitHub]](<https://github.com/valeman/awesome-conf
   
 ## Misclassification Detection & Selective Classification
 
+**Conference**
+
 - A Data-Driven Measure of Relative Uncertainty for Misclassification Detection [[ICLR2024]](https://arxiv.org/abs/2306.01710)
 - Plugin estimators for selective classification with out-of-distribution detection [[ICLR2024]](https://arxiv.org/abs/2301.12386)
 - SURE: SUrvey REcipes for building reliable and robust deep networks [[CVPR2024]](https://arxiv.org/abs/2403.00543) - [[PyTorch]](https://yutingli0606.github.io/SURE/)
 - Augmenting Softmax Information for Selective Classification with Out-of-Distribution Data [[ACCV2022]](<https://openaccess.thecvf.com/content/ACCV2022/html/Xia_Augmenting_Softmax_Information_for_Selective_Classification_with_Out-of-Distribution_Data_ACCV_2022_paper.html>)
 - Anomaly Detection via Reverse Distillation from One-Class Embedding [[CVPR2022]](<https://arxiv.org/abs/2201.10703>)
 - Rethinking Confidence Calibration for Failure Prediction [[ECCV2022]](<https://link.springer.com/chapter/10.1007/978-3-031-19806-9_30>) - [[PyTorch]](<https://github.com/Impression2805/FMFP>)
+
+**ArXiv**
+
+- Similarity-Distance-Magnitude Universal Verification [[arXiv2025]](<https://arxiv.org/abs/2502.20167>) - [[Python]](<https://github.com/ReexpressAI/sdm>)
 
 ## Uncertainty sources & Aleatoric and Epistemic Uncertainty Disentenglement
 


### PR DESCRIPTION
I added the main SDM paper.

This could be placed under a few different categories, including "Deterministic-Uncertainty-Methods" and "Uncertainty sources & Aleatoric and Epistemic Uncertainty Disentenglement", among others, but I placed it under "Selective Classification" since selective classification (prediction with rejection) is the target use-case for the method for typical use-cases with LLMs, as for example for test-time conditional branching.

SDM estimators have a number of unique characteristics relative to existing approaches for uncertainty quantification for the models with non-identifiable papers (e.g., LLMs). SDM estimators unify calibration, selection, and OOD detection; provide interpretability-by-exemplar to the calibration process itself as a consequence of matching into the support (training) set and a stable mapping to relevant partitions of the calibration set for non-rejected instances; have an explicit notion of the effective sample size; take into account uncertainty from the learning and data splitting processes (via iterating over data shuffles when training/calibrating); and target a quantity of interest, index-conditional calibration (i.e., joint prediction- and class-conditional calibration at a given alpha'), well-suited for selective classification.

Interestingly, with SDM estimators, we can achieve a non-vacuous notion of separation of epistemic and aleatoric uncertainty, conditional on the subset of low epistemic uncertainty instances. This can be useful for detecting label annotation errors among non-rejected instances (i.e., among the instances we most care about when used in practice). To achieve this, we simply need to sort the index-conditional calibrated instances by their estimated predictive uncertainty, and then examine those for which the predicted label is a mismatch to the ground-truth. See Table 6 in the current arXiv version. 

An SDM estimator can be used with an LLM for which the hidden states are available, or can be constructed over an ensemble of one or more proxy models and the output logits of a black-box model (e.g., from an LLM API), in which case the calibration is conditional on the black-box model and the proxy model(s).

Finally, the paper also shows how to incorporate an SDM estimator directly into the LLM training loop as part of the architecture of the LLM, which we refer to as an SDM network.

(We also have some earlier UQ works from 2022 at ICML and NeurIPS workshops, but the above paper is the recommended approach going forward.)